### PR TITLE
Added Remaining Synthesis Options From google Text To Speech Documentation

### DIFF
--- a/GoogleTTS/google_tts.py
+++ b/GoogleTTS/google_tts.py
@@ -15,6 +15,8 @@ class GoogleTTS:
         self.__url = "https://content-texttospeech.googleapis.com/v1/text:synthesize"
         self.__x_referer = "https://explorer.apis.google.com"
         self.__key: str = "AIzaSyAa8yy0GdcGPHdtD083HiGGx_S0vMPScDM"
+        self.__synthesis_type: SynthesisType = SynthesisType.TEXT
+        self.__speaker_name: str = "vi-VN-Standard-A"
         self.__language_code: str = "vi-VN"
         self.__ssml_gender: SsmlGender = SsmlGender.FEMALE
 
@@ -37,6 +39,9 @@ class GoogleTTS:
     def set_audio_encoding(self, encoding: AudioEncoding):
         self.__audio_encoding = encoding
 
+    def set_speaker_name(self, name: str):
+        self.__speaker_name = name
+
     def set_sample_rate(self, rate: int):
         self.__sample_rate_hertz = rate
 
@@ -52,10 +57,16 @@ class GoogleTTS:
     def set_effects_profile_id(self, effects_profile_id: AudioProfileID | None):
         self.__effects_profile_id = effects_profile_id
 
+    def set_synthesis_type(self, synthesis_type: SynthesisType):
+        self.__synthesis_type = synthesis_type
+
     def __prepare_body(self, text: str) -> dict:
-        _input: dict = {"text": text}
+        _input: dict = {
+            self.__synthesis_type: text
+        }
         _voice: dict = {
             "languageCode": self.__language_code,
+            "name": self.__speaker_name,
             "ssmlGender": self.__ssml_gender
         }
         _audioConfig: dict = {

--- a/GoogleTTS/google_tts.py
+++ b/GoogleTTS/google_tts.py
@@ -60,6 +60,13 @@ class GoogleTTS:
     def set_synthesis_type(self, synthesis_type: SynthesisType):
         self.__synthesis_type = synthesis_type
 
+    def get_voices(self) -> dict:
+        api_url = "https://texttospeech.googleapis.com/v1/voices"
+
+        headers = self.__prepare_headers()
+        params = self.__prepare_params()
+        return requests.get(api_url, params=params, headers=headers).json()
+
     def __prepare_body(self, text: str) -> dict:
         _input: dict = {
             self.__synthesis_type: text

--- a/GoogleTTS/google_tts.py
+++ b/GoogleTTS/google_tts.py
@@ -17,8 +17,12 @@ class GoogleTTS:
         self.__key: str = "AIzaSyAa8yy0GdcGPHdtD083HiGGx_S0vMPScDM"
         self.__language_code: str = "vi-VN"
         self.__ssml_gender: SsmlGender = SsmlGender.FEMALE
+
         self.__audio_encoding: AudioEncoding = AudioEncoding.MP3
+        self.__pitch: float = 0.0
+        self.__volume_gain_db: float = 0.0
         self.__sample_rate_hertz: int = 48000
+        self.__effects_profile_id: AudioProfileID | None = None
         self.__speaking_rate: float = 1.0
 
     def set_key(self, key: str):
@@ -39,6 +43,15 @@ class GoogleTTS:
     def set_speaking_rate(self, rate: float):
         self.__speaking_rate = rate
 
+    def set_pitch(self, pitch: float):
+        self.__pitch = pitch
+
+    def set_volume_gain_db(self, volume_gain_db: float):
+        self.__volume_gain_db = volume_gain_db
+
+    def set_effects_profile_id(self, effects_profile_id: AudioProfileID | None):
+        self.__effects_profile_id = effects_profile_id
+
     def __prepare_body(self, text: str) -> dict:
         _input: dict = {"text": text}
         _voice: dict = {
@@ -47,8 +60,13 @@ class GoogleTTS:
         }
         _audioConfig: dict = {
             "audioEncoding": self.__audio_encoding,
+            "speakingRate": self.__speaking_rate,
+            "pitch": self.__pitch,
+            "volumeGainDb": self.__volume_gain_db,
             "sampleRateHertz": self.__sample_rate_hertz,
-            "speakingRate": self.__speaking_rate
+            "effectsProfileId": [
+                self.__effects_profile_id
+            ]
         }
         body: dict = {
             "input": _input,

--- a/GoogleTTS/utils.py
+++ b/GoogleTTS/utils.py
@@ -40,3 +40,8 @@ class AudioProfileID(str, Enum):
     LARGE_BLUETOOTH_SPEAKER_CLASS_DEVICE = "large-home-entertainment-class-device"
     LARGE_AUTOMOTIVE_CLASS_DEVICE = "large-automotive-class-device"
     TELEPHONY_CLASS_DEVICE = "telephony-class-application"
+
+
+class SynthesisType(str, Enum):
+    TEXT = "text"
+    SSML = "ssml"

--- a/GoogleTTS/utils.py
+++ b/GoogleTTS/utils.py
@@ -29,3 +29,14 @@ extensions: dict = {
     AudioEncoding.MULAW: ".wav",
     AudioEncoding.ALAW: "wav"
 }
+
+
+class AudioProfileID(str, Enum):
+    WEARABLE_CLASS_DEVICE = "wearable-class-device"
+    HANDSET_CLASS_DEVICE = "handset-class-device"
+    HEADPHONE_CLASS_DEVICE = "headphone-class-device"
+    SMALL_BLUETOOTH_SPEAKER_CLASS_DEVICE = "small-bluetooth-speaker-class-device"
+    MEDIUM_BLUETOOTH_SPEAKER_CLASS_DEVICE = "medium-bluetooth-speaker-class-device"
+    LARGE_BLUETOOTH_SPEAKER_CLASS_DEVICE = "large-home-entertainment-class-device"
+    LARGE_AUTOMOTIVE_CLASS_DEVICE = "large-automotive-class-device"
+    TELEPHONY_CLASS_DEVICE = "telephony-class-application"


### PR DESCRIPTION
1. Added Remaining Options that are 
   -  `synthesis type` : Either `text` or `ssml`
   -  `name` : Speaker Name
   -  `pitch` : Incease or Decrease in semitones
   -  `volumeGainDb` : Signal Amplitude
   -  `effectsProfileId` : The synthesis sample rate (in hertz)
  
1. Introduced Setters for Above Options 

1. Implemented a method `get_voices` to retrieve a list of available voices from the Google Text-to-Speech API.

1. Introduced Enumerations for 
   -  `AudioProfileID` 
   -  `SynthesisType`
  
 to define constants related to audio profiles and synthesis types.

If there's anything do need to changed please do let me know
